### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.14.0


### PR DESCRIPTION
The `version` field is no longer supported and will be ignored. In the future, it will be completely removed. Please remove the `version` field from your Compose file.